### PR TITLE
Deploy/heroku

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,11 +6,12 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
-    "typescript": "^3.4.5"
+    "typescript": "^3.4.5", 
+    "babel-eslint": "^10.0.0"
+        
   },
   "devDependencies": {
     "eslint": "^5.12.0",
-    "babel-eslint": "^10.0.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-import": "^2.17.1",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Repository for the Founders Program project \"Howl\". May 2019",
   "main": "server.js",
   "scripts": {        
-    "client": " cd client  && SKIP_PREFLIGHT_CHECK=true npm run build",
+    "client": " cd client  && npm run build",
     "dev": " npm run client && nodemon ./src/server.js ",
     "start": "node ./src/server.js", 
     "eslint": "eslint ./src",
     "eslint:fix": "eslint --fix ./src", 
-    "heroku-postbuild": "cd client && npm i && SKIP_PREFLIGHT_CHECK=true npm run build"
+    "heroku-postbuild": "cd client && npm i && npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node ./src/server.js", 
     "eslint": "eslint ./src",
     "eslint:fix": "eslint --fix ./src", 
-    "heroku-postbuild": "npm run client"
+    "heroku-postbuild": "cd client && npm i && SKIP_PREFLIGHT_CHECK=true npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node ./src/server.js", 
     "eslint": "eslint ./src",
     "eslint:fix": "eslint --fix ./src", 
-    "heroku-postbuild": "cd client && npm install && npm run build"
+    "heroku-postbuild": "npm run client"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
References issue #54. 

You can view the deployed pull request here: https://howl-fac-pr-70.herokuapp.com/

Why this PR:
- Heroku crashed when I merged to staging (because of merged pull request #68). 

How this pull request differs from #69: 
- Fix the crash - by moving bable-eslint to dependencies instead of devDependencies in client's package.json. 

- removed preflight_check as it is not needed, apparently. heroku works just fine right now. 
