### PR TITLE
Fix/minor syntax errors

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 const App = () => {
-  return <div className="App">Hello HOWL!</div>;
+  return (
+    <Fragment>
+      <h1>Hello HOWL!</h1>
+    </Fragment>
+  );
 };
 
 export default App;

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,11 +1,7 @@
 import React from 'react';
 
-function App() {
-  return (
-    <div className="App">
-      Hello HOWL!
-    </div>
-  );
-}
+const App = () => {
+  return <div className="App">Hello HOWL!</div>;
+};
 
 export default App;


### PR DESCRIPTION
I've updated the ```<div>``` to a ```<Fragment>``` to get used to the convention so that our pages will read semantically later. I've also removed the className as we will be styled components. 

:) 

Thanks to @ali-7 who had a look through our repo and reminded us that we should be using es6 convention.

So... stateless components should be written in es6
```const Example = () => {};```

Stateful components, we can use es7 convention:

```
class Ali extends Component { 
  state = {}; 
  render(){ 
  return (
 ...some stuff
) }
