### PR TITLE
Feature/route story: each time a story is requested send the data back issue #79

### DIFF
--- a/src/controllers/getStory.js
+++ b/src/controllers/getStory.js
@@ -1,0 +1,11 @@
+const { Story } = require('../airtables');
+
+const getStory = (req, res) => {
+  const { id } = req.params;
+  Story.find(`${id}`, (err, record) => {
+    if (err) { res.json({ success: false, message: err.message }); return; }
+    res.json({ success: true, data: record._rawJson.fields });
+  });
+};
+
+module.exports = { getStory };

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,3 +1,4 @@
 const Story = require('./story');
+const getStory = require('./getStory');
 
-module.exports = { Story };
+module.exports = { Story, getStory };

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const controllers = require('./controllers');
+const { Story, getStory } = require('./controllers');
 
 const { uploadImg, multerUploads, cloudinaryConfig } = require('./middlewares/uploadImg');
 
@@ -9,6 +9,8 @@ const router = express.Router();
 
 router.post('/upload', [cloudinaryConfig, multerUploads, uploadImg]);
 
-router.post('/posts/create', controllers.Story.create);
+router.post('/posts/create', Story.create);
+
+router.get('/posts/:id', getStory.getStory);
 
 module.exports = router;


### PR DESCRIPTION
References issue #79 

What I did in this PR #79: 

- [x] Make `getStory` handler that will send back data when a story is requested following this endpoint `/posts/:id`. 

- [x] Refactored how the `create` handler is exported/imported. 

Note: To test this PR, use `Postman` with the following URL: `http://localhost:9000/posts/recvgYjQco6Pi93oB`